### PR TITLE
Workaround for beta 5+.

### DIFF
--- a/Other Projects/WWDCPlayer/WWDCPlayer.xcodeproj/project.pbxproj
+++ b/Other Projects/WWDCPlayer/WWDCPlayer.xcodeproj/project.pbxproj
@@ -34,16 +34,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		8D49A1F622A8839D002D1C10 /* VideoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VideoRow.swift; path = ../VideoRow.swift; sourceTree = "<group>"; };
+		8D49A1F622A8839D002D1C10 /* VideoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = VideoRow.swift; path = WWDCPlayer/VideoRow.swift; sourceTree = SOURCE_ROOT; };
 		8DC3392A22A89A7D00EDE8CF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8DC3392B22A89A7D00EDE8CF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8DC3393022A8A14800EDE8CF /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
-		B83D3F7A22A8529B000A9E72 /* PlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlayerViewController.swift; path = ../PlayerViewController.swift; sourceTree = "<group>"; };
+		8DC3393022A8A14800EDE8CF /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UserData.swift; path = WWDCPlayer/Model/UserData.swift; sourceTree = SOURCE_ROOT; };
+		B83D3F7A22A8529B000A9E72 /* PlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlayerViewController.swift; path = WWDCPlayer/PlayerViewController.swift; sourceTree = SOURCE_ROOT; };
 		B83D3F7C22A855C8000A9E72 /* Video.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Video.swift; sourceTree = "<group>"; };
 		B8C3352022A83894003AD9B4 /* WWDCPlayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WWDCPlayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8C3352322A83894003AD9B4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B8C3352522A83894003AD9B4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		B8C3352722A83894003AD9B4 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MainView.swift; path = ../MainView.swift; sourceTree = "<group>"; };
+		B8C3352722A83894003AD9B4 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MainView.swift; path = WWDCPlayer/MainView.swift; sourceTree = SOURCE_ROOT; };
 		B8C3352C22A83897003AD9B4 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		B8C3352F22A83897003AD9B4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B8C3353622A83897003AD9B4 /* WWDCPlayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WWDCPlayerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/Other Projects/WWDCPlayer/WWDCPlayer/MainView.swift
+++ b/Other Projects/WWDCPlayer/WWDCPlayer/MainView.swift
@@ -62,7 +62,7 @@ struct VideoListView : View {
                 Section(header: Text(day.rawValue.uppercased()).fontWeight(.bold)) {
                     ForEach(self.userData.videos.filter { $0.weekDay == day }) { video in
                         if !self.userData.showFavoriteOnly || video.isFavorite {
-                            VideoRow(video: video)
+                            VideoRow(video: video, isFavorite: video.isFavorite)
                         }
                     }
                 }

--- a/Other Projects/WWDCPlayer/WWDCPlayer/VideoRow.swift
+++ b/Other Projects/WWDCPlayer/WWDCPlayer/VideoRow.swift
@@ -13,6 +13,7 @@ struct VideoRow : View {
     @EnvironmentObject var userData: UserData
     
     var video: Video
+    var isFavorite = false
     
     var body: some View {
         HStack {


### PR DESCRIPTION
There was a slight regression in beta5 which meant the isFavourite star in the WWDC Player example stopped updating. This workaround fixes this for now. I have a radar open.