### PR TITLE
ADD Missing navigation for SpotlightSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ and follow me on GitHub:
 - [FlipClock-SwiftUI](#FlipClock-SwiftUI)
 - [Currency Converter & Calculator](#transition-and-blur)
 - [Countdown Film Clutter](#CountdownFilmClutter-SwiftUI)
+- [SpotlightSearch](#SpotlightSearch)
 
 Also include:
 - Movie


### PR DESCRIPTION
Wow, thank you!

I missed navigation section link in README.md for SpotlightSearch
It's simple addition for navigation.

Thank you for your merge!


